### PR TITLE
Sanitize object names

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,12 @@
     "url": "https://github.com/lispercat/sailpoint-iiq-dev-accelerator/issues"
   },
   "homepage": "https://github.com/lispercat/sailpoint-iiq-dev-accelerator#readme",
-  "dependencies": {},
-  "devDependencies": {}
+  "scripts": {
+    "test": "mocha ./out/test/**.js",
+    "compile": "tsc -b",
+    "pretest": "npm run compile"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0"
+  }
 }

--- a/client/src/iiq-commands.ts
+++ b/client/src/iiq-commands.ts
@@ -13,7 +13,7 @@ var xpath = require('xpath')
 import {DOMParser, XMLSerializer} from '@xmldom/xmldom'
 import {API as GitAPI, Repository, GitExtension, Status} from './typings/git';
 import {PathProposer} from './pathProposer';
-import {beautifyIIQObject} from './xmlUtils';
+import {beautifyIIQObject, sanitizeIIQObjectName} from './xmlUtils';
 import { integer } from 'vscode-languageclient';
 
 const fg = require('fast-glob');
@@ -2214,7 +2214,8 @@ export class IIQCommands {
             }
             progress.report({increment: incr, message: `${aClass} "${objName}"`});
             var xml = await this.searchObject(aClass, null, objName, false, useTokenization);
-            fs.writeFileSync(`${classFolder}/${objName}.xml`, xml, {encoding: 'utf8', flag: 'w'});
+            const sanitizedName = sanitizeIIQObjectName(objName)
+            fs.writeFileSync(`${classFolder}/${sanitizedName}.xml`, xml, {encoding: 'utf8', flag: 'w'});
             exportedCount++;
           }
         }

--- a/client/src/test/xmlUtils.test.ts
+++ b/client/src/test/xmlUtils.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert'
+import { sanitizeIIQObjectName } from '../xmlUtils'
+
+describe('Sanitize Object Names', () => {
+    it("should remove forward slashes from object names", () => {
+        const objName = "someObject/Name123"
+        const sanitized = sanitizeIIQObjectName(objName)
+        assert.strictEqual(sanitized, "someObject_Name123", "object name does not match as expected")
+    })
+
+    it("should remove backslashes from object name", () => {
+        const objName = "someObject\\Name123"
+        const sanitized = sanitizeIIQObjectName(objName)
+        assert.strictEqual(sanitized, "someObject_Name123", "object name does not match as expected")
+    })
+
+    it("should not remove dots from object names", () => {
+        const objName = "someObject.Name123"
+        const sanitized = sanitizeIIQObjectName(objName)
+        assert.strictEqual(sanitized, objName, "there should be no change to this object's name")
+    })
+
+    it("should not remove hyphens from object names", () => {
+        const objName = "someObject-Name123"
+        const sanitized = sanitizeIIQObjectName(objName) 
+        assert.strictEqual(sanitized, objName, "there should be no change to this object's name")
+    })
+    
+    it("should not remove underscores from object names", () => {
+        const objName = "someObject_Name123"
+        const sanitized = sanitizeIIQObjectName(objName) 
+        assert.strictEqual(sanitized, objName, "there should be no change to this object's name")
+    })
+
+    it("should replace whitespace with underscores", () => {
+        const objName = "someObject Name123"
+        const sanitized = sanitizeIIQObjectName(objName) 
+        assert.strictEqual(sanitized, "someObject_Name123", "there should be no spaces left in the object name") 
+    })
+
+    it("should replace other non-alphanumeric characters with underscores", () => {
+        const objName = "some#Object&N@me123"
+        const sanitized = sanitizeIIQObjectName(objName)
+        assert.strictEqual(sanitized, "some_Object_N_me123", "object name does not match expected output")
+    })
+})

--- a/client/src/xmlUtils.ts
+++ b/client/src/xmlUtils.ts
@@ -65,3 +65,12 @@ export function beautifyIIQObject(sourceXml: string, className: string): string 
     return xml
 }
 
+/**
+ * Replaces "illegal" characters (anything other than alphanumeric characters, dots, or hyphens) with underscores in the name of an IIQ Object.
+ * "Illegal" characters are defined as such in the documentation for the Sailpoint-provided XML Object Exporter Task. 
+ * @param objectName
+ * @returns object name with problematic characters changed to underscores
+ */
+export function sanitizeIIQObjectName(objectName: string): string {
+    return objectName.replace(/[^-a-zA-Z0-9_.]+/g, "_")
+}

--- a/server/src/scratch.ts
+++ b/server/src/scratch.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 var xpath = require('xpath')
-import { DOMParser } from 'xmldom'
-import { XMLSerializer } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
+import { XMLSerializer } from '@xmldom/xmldom'
 
 let xml = fs.readFileSync("D:/Dev/sailpoint-iiq-ssd-base/config/Application/TestApp.xml",'utf8');
 var doc = new DOMParser().parseFromString(xml)


### PR DESCRIPTION
Could potentially address #58. With this code in place, I was able to successfully export objects with slashes in the name.