### PR TITLE
Add support for unicode characters in object name sanitizer.

### DIFF
--- a/client/src/test/xmlUtils.test.ts
+++ b/client/src/test/xmlUtils.test.ts
@@ -43,4 +43,10 @@ describe('Sanitize Object Names', () => {
         const sanitized = sanitizeIIQObjectName(objName)
         assert.strictEqual(sanitized, "some_Object_N_me123", "object name does not match expected output")
     })
+
+    it("should not replace or remove unicode characters", () => {
+        const objName = "ЭКСПЕРТНЫЙ ОТДЕЛ"
+        const sanitized = sanitizeIIQObjectName(objName)
+        assert.strictEqual(sanitized, "ЭКСПЕРТНЫЙ_ОТДЕЛ", "object name does not match expected output")
+    })
 })

--- a/client/src/xmlUtils.ts
+++ b/client/src/xmlUtils.ts
@@ -72,5 +72,5 @@ export function beautifyIIQObject(sourceXml: string, className: string): string 
  * @returns object name with problematic characters changed to underscores
  */
 export function sanitizeIIQObjectName(objectName: string): string {
-    return objectName.replace(/[^-a-zA-Z0-9_.]+/g, "_")
+    return objectName.replace(/[^-0-9\p{L}._]+/gu, "_")
 }


### PR DESCRIPTION
Someone (no idea who*) broke object exports if they had unicode/foreign language characters in the name. This change fixes that problem.

*it was me

![image](https://github.com/lispercat/sailpoint-iiq-dev-accelerator/assets/25092687/9fb214fc-c908-4ff1-88c3-7b1107dd9e9c)
