### PR TITLE
Fix for issue #74: properties file reader does not handle escape chars properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "sailpoint-iiq-dev-accelerator",
-    "version": "10.0.58",
+    "version": "10.0.59",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -269,7 +269,8 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "agent-base": {
             "version": "6.0.2",
@@ -1606,11 +1607,6 @@
                 "kind-of": "^6.0.3"
             }
         },
-        "mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        },
         "mocha": {
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.2.2.tgz",
@@ -1862,13 +1858,10 @@
             "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
             "dev": true
         },
-        "properties-reader": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-2.2.0.tgz",
-            "integrity": "sha512-CgVcr8MwGoBKK24r9TwHfZkLLaNFHQ6y4wgT9w/XzdpacOOi5ciH4hcuLechSDAwXsfrGQtI2JTutY2djOx2Ow==",
-            "requires": {
-                "mkdirp": "^1.0.4"
-            }
+        "properties-file": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/properties-file/-/properties-file-3.6.0.tgz",
+            "integrity": "sha512-bpR0vxUlpjiVHaMDCr/x3RFVbR+6eN5BeLGK9ZZ3qEfSLFUNK5FJqjinulKfrkpcr0GqyOeWW58I+hDOWiA7ag=="
         },
         "proxy-from-env": {
             "version": "1.1.0",
@@ -2149,6 +2142,15 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "string-width": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2158,15 +2160,6 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.0"
             }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Sailpoint IIQ Development Accelerator",
     "description": "Provides commands to facilitate/accelerate coding/interacting with remote Sailpoint IIQ server",
     "icon": "images/icon.png",
-    "version": "10.0.58",
+    "version": "10.0.59",
     "engines": {
         "vscode": "^1.60.0"
     },
@@ -393,7 +393,7 @@
         "base-64": "^1.0.0",
         "fast-glob": "^3.2.8",
         "node-fetch": "^2.6.7",
-        "properties-reader": "^2.2.0",
+        "properties-file": "^3.6.0",
         "saxon-js": "^2.6.0",
         "semver": "^7.5.4",
         "tmp": "^0.2.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "sailpoint-iiq-dev-accelerator-language-server",
   "version": "0.0.1",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true
 }


### PR DESCRIPTION
* Remove the properties-reader dependency.
* Add the new properties-file dependency.
* Also, a handful of Typescript updates from 'var' to 'let'.
* Bumped version to .59

Appears to work in my own testing with the following properties:

```
%%TEST%%=jdbc\:oracle\:thin\:@localhost:1521:xe

%%TEST2%%\==\a\b\c
```

This resolves to properly un-escaped tokens `%%TEST%%` and `%%TEST2%%=`. 